### PR TITLE
Improve word randomization

### DIFF
--- a/api/get-word.js
+++ b/api/get-word.js
@@ -22,7 +22,8 @@ const categories = [
   "weather", "clothing", "architecture", "mythology",
 ];
 
-const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const allLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const beginnerLetters = "ABCDEFGHIJKLMNOPRSTUVW";
 
 export default async function handler(req, res) {
   if (req.method !== "POST") {
@@ -35,7 +36,8 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: "Invalid level" });
   }
 
-  const randomLetter = letters[Math.floor(Math.random() * letters.length)];
+  const pool = level === "Beginner" ? beginnerLetters : allLetters;
+  const randomLetter = pool[Math.floor(Math.random() * pool.length)];
   const randomCategory =
     categories[Math.floor(Math.random() * categories.length)];
   const [min, max] = lengthRanges[level];

--- a/api/get-word.js
+++ b/api/get-word.js
@@ -9,16 +9,37 @@ const levelDescriptions = {
     "a very rare, obscure, or highly technical word that most people would not know",
 };
 
+const lengthRanges = {
+  Beginner: [3, 6],
+  Intermediate: [4, 8],
+  Advanced: [5, 10],
+  Expert: [7, 14],
+};
+
+const categories = [
+  "nature", "science", "food", "history", "music", "sports",
+  "medicine", "geography", "technology", "literature", "animals",
+  "weather", "clothing", "architecture", "mythology",
+];
+
+const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
 export default async function handler(req, res) {
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  const { level, timestamp } = req.body;
+  const { level } = req.body;
 
   if (!level || !levelDescriptions[level]) {
     return res.status(400).json({ error: "Invalid level" });
   }
+
+  const randomLetter = letters[Math.floor(Math.random() * letters.length)];
+  const randomCategory =
+    categories[Math.floor(Math.random() * categories.length)];
+  const [min, max] = lengthRanges[level];
+  const randomLength = Math.floor(Math.random() * (max - min + 1)) + min;
 
   const openai = new OpenAI({
     apiKey: process.env.GITHUB_TOKEN,
@@ -30,10 +51,10 @@ export default async function handler(req, res) {
     messages: [
       {
         role: "user",
-        content: `Give me ${levelDescriptions[level]} and its definition on a separate line. CRITICAL: You must pick a genuinely random word — do NOT default to the same common words you typically suggest. The English language has hundreds of thousands of words; explore the full breadth of it. Actively avoid words you have given before. The current timestamp is ${timestamp} — use this as a random seed to vary your selection every single time. Your entire response must use English characters only — do not include any characters from other scripts or languages. Don't say anything else except that, your response has to only have two lines. Example:\nAvuncular\nKind, friendly, and generous, especially to younger or less experienced people.`,
+        content: `Give me ${levelDescriptions[level]} related to the topic "${randomCategory}" that starts with the letter "${randomLetter}" and is around ${randomLength} letters long. Provide the word and its definition on a separate line. Your entire response must use English characters only — do not include any characters from other scripts or languages. Don't say anything else except that, your response has to only have two lines. Example:\nAvuncular\nKind, friendly, and generous, especially to younger or less experienced people.`,
       },
     ],
-    temperature: 1.5,
+    temperature: 1,
   });
 
   const lines = response.choices[0].message.content.split("\n");

--- a/src/Game.js
+++ b/src/Game.js
@@ -31,7 +31,7 @@ const Game = () => {
       const response = await fetch("/api/get-word", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ level: selectedLevel, timestamp: Date.now() }),
+        body: JSON.stringify({ level: selectedLevel }),
       });
 
       if (!response.ok) throw new Error("API error");


### PR DESCRIPTION
- Add randomized constraints to the word API by introducing lengthRanges, categories, and letters and sampling a random category, starting letter, and target length for each request. Beginner gets a subset of the letters available.
- Update the OpenAI prompt to require a word matching those criteria and reduce temperature from 1.5 to 1. Remove the timestamp seed from the request/handler and update src/Game.js to stop sending the timestamp in the POST body.
- I tested each level 20 times and there were no duplicates